### PR TITLE
Mysql 8.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Setup
 ---
 - **Clone Source**
 ```shell
+sudo apt install libmysqlclient-dev
 git clone https://github.com/parthasai/mysql_udf_http_golang.git udf
 cd udf
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # mysql_udf_http_golang
+Now works for Mysql 8+ also.
+
 [![MySQL UDF](https://img.shields.io/badge/MySQL-UDF-blue.svg)](https://dev.mysql.com/) [![MariaDB UDF](https://img.shields.io/badge/MariaDB-UDF-blue.svg)](https://mariadb.com/)
 
 [MySQL](https://dev.mysql.com/) or [MariaDB](https://mariadb.com/) UDF(User-Defined Functions) HTTP Client Plugin
@@ -9,7 +11,7 @@ Setup
 ---
 - **Clone Source**
 ```shell
-git clone https://github.com/2rebi/mysql_udf_http_golang.git udf
+git clone https://github.com/parthasai/mysql_udf_http_golang.git udf
 cd udf
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Setup
 ---
 - **Clone Source**
 ```shell
-sudo apt install libmysqlclient-dev
+sudo apt install libmysqlclient-dev golang-go
 git clone https://github.com/parthasai/mysql_udf_http_golang.git udf
 cd udf
 ```

--- a/http.go
+++ b/http.go
@@ -192,7 +192,7 @@ func httpRaw(method string, url string, contentType string, body string, options
 }
 
 //export http_raw_init
-func http_raw_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.my_bool {
+func http_raw_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.int {
 	if args.arg_count < 3 {
 		msg := `
 		http_raw(method string, url string, body string, option ...string) requires method, url, body argment
@@ -237,7 +237,7 @@ func http_raw(initid *C.UDF_INIT, args *C.UDF_ARGS, result *C.char, length *uint
 }
 
 //export http_get_init
-func http_get_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.my_bool {
+func http_get_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.int {
 	if args.arg_count == 0 {
 		msg := `
 		http_get(url string, option ...string) requires url argment
@@ -273,7 +273,7 @@ func http_get(initid *C.UDF_INIT, args *C.UDF_ARGS, result *C.char, length *uint
 }
 
 //export http_post_init
-func http_post_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.my_bool {
+func http_post_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.int {
 	if args.arg_count < 3 {
 		msg := `
 		http_post(url string, contentType string, body string, option ...string) requires url, contentType, body argment
@@ -308,7 +308,7 @@ func http_post(initid *C.UDF_INIT, args *C.UDF_ARGS, result *C.char, length *uin
 }
 
 //export http_help_init
-func http_help_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.my_bool {
+func http_help_init(initid *C.UDF_INIT, args *C.UDF_ARGS, message *C.char) C.int {
 	return 0
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,16 +7,16 @@ if [[ $# > 0 ]]; then
     fi
 
     sql_result=$(mysql --user=$1 --password=$2 -s -N -e "SHOW VARIABLES LIKE 'plugin_dir';")
-    plugin_dir=$(cut -d" " -f2 <<< $sql_result)
+    plugin_dir=$(awk '{print $2}' <<< "$sql_result")
 
     export CGO_CFLAGS=$include_dir
     go build -buildmode=c-shared -o $plugin_dir"http.so" http.go
     rm $plugin_dir"http.h"
 
-    mysql --user=$1 --password=$2 -s -N -e "CREATE OR REPLACE FUNCTION http_help RETURNS STRING SONAME 'http.so';"
-    mysql --user=$1 --password=$2 -s -N -e "CREATE OR REPLACE FUNCTION http_raw RETURNS STRING SONAME 'http.so';"
-    mysql --user=$1 --password=$2 -s -N -e "CREATE OR REPLACE FUNCTION http_get RETURNS STRING SONAME 'http.so';"
-    mysql --user=$1 --password=$2 -s -N -e "CREATE OR REPLACE FUNCTION http_post RETURNS STRING SONAME 'http.so';"
+    mysql --user=$1 --password=$2 -s -N -e "CREATE FUNCTION http_help RETURNS STRING SONAME 'http.so';"
+    mysql --user=$1 --password=$2 -s -N -e "CREATE FUNCTION http_raw RETURNS STRING SONAME 'http.so';"
+    mysql --user=$1 --password=$2 -s -N -e "CREATE FUNCTION http_get RETURNS STRING SONAME 'http.so';"
+    mysql --user=$1 --password=$2 -s -N -e "CREATE FUNCTION http_post RETURNS STRING SONAME 'http.so';"
 
     echo "Install Success"
 else

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,7 +5,7 @@ if [[ $# > 0 ]]; then
     mysql --user=$1 --password=$2 -s -N -e "DROP FUNCTION http_post;"
     
     sql_result=$(mysql --user=$1 --password=$2 -s -N -e "SHOW VARIABLES LIKE 'plugin_dir';")
-    plugin_dir=$(cut -d" " -f2 <<< $sql_result)
+    plugin_dir=$(awk '{print $2}' <<< "$sql_result")
     rm $plugin_dir"http.so"
 
     echo "Uninstall Success"


### PR DESCRIPTION
1. Instead of using the unsupported my_bool variable in MySQL 8, have replaced it with int.
2. In the install.sh and uninstall.sh scripts, modified the mechanism for extracting the plugin_dir. Previously, it was outputting 'plugin_dir <path>', which caused issues in the subsequent steps. Now, the extraction correctly provides only plugin directory path.
3. Updated readme file to include installation of libmysqlclient-dev golang-go packages